### PR TITLE
[Fix: PaymentModal.tsx] お釣りのテキストを選択できないように

### DIFF
--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -43,7 +43,7 @@ export default function PaymentModal({ opened, orderPrise, onClose, onPaymentSub
       <NumPad value={numValue} onChange={setNumValue} />
       <Stack p="sm" spacing="sm">
         <Center>
-          <Text size="xl">{
+          <Text size="xl" style={{ userSelect: "none", WebkitUserSelect: "none" }}>{
             numValue >= orderPrise ? (
               `お釣り: ¥${(numValue - orderPrise).toLocaleString()}`
             ) : (


### PR DESCRIPTION
# 内容

iPadで金額を入力しているときに、消去ボタンの連打/長押し時にお釣りのテキストを選択してしまい、誤ってメニューをタッチしてしまうことがあったので、テキストを選択できないようにした